### PR TITLE
feat: Add work experience section to homepage

### DIFF
--- a/components/WorkExperience.vue
+++ b/components/WorkExperience.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="flex flex-col gap-3 mb-6">
+    <div class="flex flex-col gap-1">
+      <h3 class="text-lg font-semibold text-yellow-950">
+        {{ title }}
+      </h3>
+      <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-1">
+        <p class="text-base font-medium text-sienna-700">
+          {{ company }}
+        </p>
+        <p class="text-sm font-medium text-gray-600">
+          {{ duration }}
+        </p>
+      </div>
+    </div>
+    <ul class="list-disc list-outside ml-5 space-y-1.5">
+      <li
+        v-for="(item, index) in responsibilities"
+        :key="index"
+        class="text-sm text-yellow-950/90 leading-relaxed"
+      >
+        {{ item }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title: string
+  company: string
+  duration: string
+  responsibilities: string[]
+}
+
+defineProps<Props>()
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,7 +40,37 @@
           <span class="text-pink-800/70 text-3xl relative ">
             → Work Experiences
           </span>
-          QQ
+          <div class="text-yellow-950 space-y-2">
+            <WorkExperience
+              title="Software Engineer"
+              company="MyProGuide Japan"
+              duration="Apr 2025 - Now"
+              :responsibilities="[
+                'Developed full-stack travel and SaaS platforms (20k+ MAU) using Vue 3/Nuxt.js with TypeScript, Pinia, and hybrid CSR/SSR for frontend with lazy loading optimization, and Koa for RESTful backend microservices.',
+                'Automated deployment and maintained cloud infrastructure on GCP with Kubernetes and Cloud Run via GitHub Actions, configured Cloudflare edge caching and CDN, reducing Google Places API costs by 99%.',
+                'Developed AI email parsing pipeline using LLM and prompt engineering for automated customer information extraction and categorization, integrated RESTful third-party OTA service APIs (Trip.com) for booking management.'
+              ]"
+            />
+            <WorkExperience
+              title="Front-end Software Engineer I"
+              company="Garmin Ltd."
+              duration="Sep 2024 - Mar 2025"
+              :responsibilities="[
+                'Led a smart factory dashboard project as project leader, leveraging Angular and TypeScript to build an MQTT-based SPA with data visualization and live video streaming to control and monitor AGVs and assembly lines.',
+                'Established a design system using Storybook and Tailwind CSS with standardized UI/UX patterns, refactored legacy UI components into reusable templates for manufacturing systems and analytical dashboards.'
+              ]"
+            />
+            <WorkExperience
+              title="Network and System Administrator / Site Reliability Engineer"
+              company="NTU Digital Learning Center"
+              duration="Jul 2023 - May 2025"
+              :responsibilities="[
+                'Orchestrated zero-downtime migration of NTU COOL PostgreSQL database from outdated Ubuntu 16.04 using streaming replication and high availability setup, ensuring 99.9% uptime for over 40,000 daily users.',
+                'Deployed Prometheus and Grafana for infrastructure monitoring and observability, implemented automated Slack alerting, and performed network troubleshooting to resolve packet loss on Proxmox VE hypervisor.',
+                'Administered self-hosted GitLab DevOps platform using Docker Compose and Nginx reverse proxy, configured GitLab Runners for automated CI/CD pipelines deploying to Kubernetes clusters.'
+              ]"
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Created WorkExperience component to display job details with title, company, duration, and responsibilities. Added three work experiences:
- Software Engineer at MyProGuide Japan
- Front-end Software Engineer I at Garmin Ltd.
- Network and System Administrator / SRE at NTU Digital Learning Center

Replaced placeholder "QQ" text with detailed work experience entries.

https://claude.ai/code/session_012SEKanrahVKwiDRwejqA1m